### PR TITLE
Allow customization of the packager configs from the apps package.json

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -121,7 +121,7 @@ function pack(arch: string, callback: (error: any, result: any) => void) {
     console.log("Skipping app dependencies installation because dev and app dependencies are not separated")
   }
 
-  packager(merge(appPackageJson.build || {}, {
+  packager(merge({
     dir: appDir,
     out: args.platform === "win32" ? path.join(distDir, "win") : distDir,
     name: appPackageJson.name,
@@ -141,20 +141,20 @@ function pack(arch: string, callback: (error: any, result: any) => void) {
       ProductName: appPackageJson.name,
       InternalName: appPackageJson.name,
     }
-  }), callback)
+  }, appPackageJson.build || {}), callback)
 }
 
 function build(arch: string, distPath: string, callback: (error: any, result: any) => void) {
   if (args.platform === "darwin") {
-    require("electron-builder").init().build(merge(appPackageJson.darwinPackager || {}, {
+    require("electron-builder").init().build(merge({
       "appPath": distPath,
       "platform": args.platform === "darwin" ? "osx" : (args.platform == "win32" ? "win" : args.platform),
       "out": outDir,
       "config": path.join(process.cwd(), "build", "packager.json"),
-    }), callback)
+    }, appPackageJson.darwinPackager || {}), callback)
   }
   else {
-    require('electron-installer-squirrel-windows')(merge(appPackageJson.windowsPackager || {}, {
+    require('electron-installer-squirrel-windows')(merge({
       name: appPackageJson.name,
       path: distPath,
       product_name: appPackageJson.name,
@@ -163,7 +163,7 @@ function build(arch: string, distPath: string, callback: (error: any, result: an
       description: appPackageJson.description,
       authors: appPackageJson.author,
       setup_icon: path.join(process.cwd(), "build", "icon.ico"),
-    }), callback)
+    }, appPackageJson.windowsPackager || {}), callback)
   }
 }
 

--- a/src/build.ts
+++ b/src/build.ts
@@ -146,15 +146,15 @@ function pack(arch: string, callback: (error: any, result: any) => void) {
 
 function build(arch: string, distPath: string, callback: (error: any, result: any) => void) {
   if (args.platform === "darwin") {
-    require("electron-builder").init().build({
+    require("electron-builder").init().build(merge(appPackageJson.darwinPackager || {}, {
       "appPath": distPath,
       "platform": args.platform === "darwin" ? "osx" : (args.platform == "win32" ? "win" : args.platform),
       "out": outDir,
       "config": path.join(process.cwd(), "build", "packager.json"),
-    }, callback)
+    }), callback)
   }
   else {
-    require('electron-installer-squirrel-windows')({
+    require('electron-installer-squirrel-windows')(merge(appPackageJson.windowsPackager || {}, {
       name: appPackageJson.name,
       path: distPath,
       product_name: appPackageJson.name,
@@ -163,7 +163,7 @@ function build(arch: string, distPath: string, callback: (error: any, result: an
       description: appPackageJson.description,
       authors: appPackageJson.author,
       setup_icon: path.join(process.cwd(), "build", "icon.ico"),
-    }, callback)
+    }), callback)
   }
 }
 


### PR DESCRIPTION
Some people need to customize these options aswell, this just implements the same merge technique used for the `builder` configuration

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/develar/electron-complete-builder/1)

<!-- Reviewable:end -->
